### PR TITLE
Define conflict with psb-bernard-dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         "messaging",
         "bernard"
     ],
+    "conflict": {
+        "prooph/psb-bernard-dispatcher": "*"
+    }
     "require": {
         "php": "~5.5|~7.0",
         "prooph/common": "^3.5",


### PR DESCRIPTION
This change adds a conflict statement to composer.json which
marks this package as conflicting with the abandoned package
prroph/psb-bernard-dispatcher
